### PR TITLE
Fix for unescaped newline and vid/vkey parameters

### DIFF
--- a/src/commands/policy-scan.yml
+++ b/src/commands/policy-scan.yml
@@ -78,9 +78,9 @@ steps:
       name: "Upload to Veracode"
       no_output_timeout: 30m
       command: |
-        java -jar /opt/veracode/api-wrapper.jar
-        -vid "<< parameters.vid >>" \
-        -vkey "<< parameters.vkey >>" \
+        java -jar /opt/veracode/api-wrapper.jar \
+        -vid "${<< parameters.vid >>}" \
+        -vkey "${<< parameters.vkey >>}" \
         -teams "<< parameters.teams >>" \
         -action UploadAndScan \
         -appname "<< parameters.appname >>" \


### PR DESCRIPTION
The policy-scan command currently fails due to a few syntax errors, this should resolve them.